### PR TITLE
fix: use filtered query param map

### DIFF
--- a/lib/src/extensions.dart
+++ b/lib/src/extensions.dart
@@ -361,7 +361,7 @@ extension GoRouterX on GoRouter {
       );
     }
 
-    return namedLocation(name, pathParameters: state.pathParameters, queryParameters: state.uri.queryParametersAll);
+    return namedLocation(name, pathParameters: pathParameters, queryParameters: state.uri.queryParametersAll);
   }
 
   bool isAtLocation(GoRouterState state, GuardAwareGoRoute item) {


### PR DESCRIPTION
This should have been added with https://github.com/harkairt/guarded_go_router/pull/18