### PR TITLE
chore: 0.0.15

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.0.15
+
+- fix: cover continue path resolution for sequential Guard1→Guard2 flow in nested and flattened shield
+
 ## 0.0.14
 
 - fix: properly evaluate every enclosing guard even if destination is shield of a passing guard

--- a/lib/src/guarded_go_router.dart
+++ b/lib/src/guarded_go_router.dart
@@ -90,6 +90,13 @@ class GuardedGoRouter {
         state: state,
         fn: (context, state) {
           logger?.call("👉🏻👉🏻👉🏻 ${state.uri.toString().sanitized}");
+          final hasResolvedRoute = (state.topRoute?.name ?? state.name) != null;
+          if (!hasResolvedRoute) {
+            final continuePath = state.maybeResolveContinuePath();
+            if (continuePath != null) {
+              return continuePath;
+            }
+          }
           return null;
         },
         relay: (context, state) {
@@ -168,13 +175,13 @@ class GuardedGoRouter {
         throw FollowUpRouteMissingException(discardingGuards.first.runtimeType);
       }
 
-      if (isParentOf(routeName: thisName, maybeParentRouteName: firstFollowUpRouteName)) {
-        return null;
-      }
-
       final resolvedContinuePath = state.maybeResolveContinuePath();
       if (resolvedContinuePath != null) {
         return resolvedContinuePath;
+      }
+
+      if (isParentOf(routeName: thisName, maybeParentRouteName: firstFollowUpRouteName)) {
+        return null;
       }
 
       return goRouter.namedLocationFrom(

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,7 +1,7 @@
 name: guarded_go_router
 description: This package aims to provide a guard mechanism to a project using go_router and riverpod
 repository: https://github.com/harkairt/guarded_go_router
-version: 0.0.14
+version: 0.0.15
 
 environment:
   sdk: ">=3.6.2 <4.0.0"

--- a/test/guarded_go_router_test.dart
+++ b/test/guarded_go_router_test.dart
@@ -2166,6 +2166,51 @@ void main() {
           await tester.pumpAndSettle();
           expect(router.location.sanitized, "/home");
         });
+
+        testWidgets('interactive flow resolves continue path through sequentially dependent guards', (WidgetTester tester) async {
+          activateGuard(guard: guard1);
+          activateGuard(guard: guard2);
+
+          final router = await pumpRouter(
+            tester,
+            guards: [guard1, guard2],
+            routes: [
+              _goRoute(
+                "shield1",
+                shieldOf: [Guard1],
+                discardedBy: [Guard1],
+                routes: [
+                  _goRoute(
+                    "shield2",
+                    followUp: [Guard1],
+                    discardedBy: [Guard2],
+                    shieldOf: [Guard2],
+                  ),
+                ],
+              ),
+              _guardShell<Guard1>([
+                _guardShell<Guard2>([
+                  _goRoute(
+                    "home",
+                    followUp: [Guard2],
+                  ),
+                ]),
+              ]),
+            ],
+          );
+
+          router.go("/home");
+          await tester.pumpAndSettle();
+          expect(router.location.sanitized, "/shield1?continue=/home");
+
+          deactivateGuard(guard: guard1);
+          await tester.pumpAndSettle();
+          expect(router.location.sanitized, "/shield1/shield2?continue=/home");
+
+          deactivateGuard(guard: guard2);
+          await tester.pumpAndSettle();
+          expect(router.location.sanitized, "/home");
+        });
       });
     });
 

--- a/test/guarded_go_router_test.dart
+++ b/test/guarded_go_router_test.dart
@@ -1444,7 +1444,8 @@ void main() {
             expect(router.location.sanitized, "/shield4?continue=/home");
           });
 
-          testWidgets("even if destination is the shield of an enclosing passing guard, first blocking middle guard wins", (
+          testWidgets(
+              "even if destination is the shield of an enclosing passing guard, first blocking middle guard wins", (
             WidgetTester tester,
           ) async {
             reset(guard1);
@@ -1481,7 +1482,8 @@ void main() {
             expect(router.location.sanitized, "/shield3?continue=/home");
           });
 
-          testWidgets("even if destination is the shield of an enclosing passing guard, first of multiple blocking guards wins",
+          testWidgets(
+              "even if destination is the shield of an enclosing passing guard, first of multiple blocking guards wins",
               (
             WidgetTester tester,
           ) async {
@@ -2127,6 +2129,42 @@ void main() {
 
           await tester.pumpAndSettle();
           expect(router.location.sanitized, "/route");
+        });
+
+        testWidgets('then resolve continue path even when enclosed by sequentially dependent passing guards', (WidgetTester tester) async {
+          final router = await pumpRouter(
+            tester,
+            guards: [guard1, guard2],
+            routes: [
+              _goRoute(
+                "shield1",
+                shieldOf: [Guard1],
+                discardedBy: [Guard1],
+                routes: [
+                  _goRoute(
+                    "shield2",
+                    followUp: [Guard1],
+                    discardedBy: [Guard2],
+                    shieldOf: [Guard2],
+                  ),
+                ],
+              ),
+              _guardShell<Guard1>([
+                _guardShell<Guard2>([
+                  _goRoute(
+                    "home",
+                    followUp: [Guard2],
+                  ),
+                ]),
+              ]),
+            ],
+          );
+
+          // router.go("/home");
+          router.go("/shield2?continue=/home");
+
+          await tester.pumpAndSettle();
+          expect(router.location.sanitized, "/home");
         });
       });
     });

--- a/test/guarded_go_router_test.dart
+++ b/test/guarded_go_router_test.dart
@@ -2167,6 +2167,39 @@ void main() {
           expect(router.location.sanitized, "/home");
         });
 
+        testWidgets('then resolve continue path even when enclosed by sequentially dependent passing guards (flattened)', (WidgetTester tester) async {
+          final router = await pumpRouter(
+            tester,
+            guards: [guard1, guard2],
+            routes: [
+              _goRoute(
+                "shield1",
+                shieldOf: [Guard1],
+                discardedBy: [Guard1],
+              ),
+              _goRoute(
+                "shield2",
+                followUp: [Guard1],
+                discardedBy: [Guard2],
+                shieldOf: [Guard2],
+              ),
+              _guardShell<Guard1>([
+                _guardShell<Guard2>([
+                  _goRoute(
+                    "home",
+                    followUp: [Guard2],
+                  ),
+                ]),
+              ]),
+            ],
+          );
+
+          router.go("/shield2?continue=/home");
+
+          await tester.pumpAndSettle();
+          expect(router.location.sanitized, "/home");
+        });
+
         testWidgets('interactive flow resolves continue path through sequentially dependent guards', (WidgetTester tester) async {
           activateGuard(guard: guard1);
           activateGuard(guard: guard2);
@@ -2206,6 +2239,49 @@ void main() {
           deactivateGuard(guard: guard1);
           await tester.pumpAndSettle();
           expect(router.location.sanitized, "/shield1/shield2?continue=/home");
+
+          deactivateGuard(guard: guard2);
+          await tester.pumpAndSettle();
+          expect(router.location.sanitized, "/home");
+        });
+
+        testWidgets('interactive flow resolves continue path through sequentially dependent guards (flattened)', (WidgetTester tester) async {
+          activateGuard(guard: guard1);
+          activateGuard(guard: guard2);
+
+          final router = await pumpRouter(
+            tester,
+            guards: [guard1, guard2],
+            routes: [
+              _goRoute(
+                "shield1",
+                shieldOf: [Guard1],
+                discardedBy: [Guard1],
+              ),
+              _goRoute(
+                "shield2",
+                followUp: [Guard1],
+                discardedBy: [Guard2],
+                shieldOf: [Guard2],
+              ),
+              _guardShell<Guard1>([
+                _guardShell<Guard2>([
+                  _goRoute(
+                    "home",
+                    followUp: [Guard2],
+                  ),
+                ]),
+              ]),
+            ],
+          );
+
+          router.go("/home");
+          await tester.pumpAndSettle();
+          expect(router.location.sanitized, "/shield1?continue=/home");
+
+          deactivateGuard(guard: guard1);
+          await tester.pumpAndSettle();
+          expect(router.location.sanitized, "/shield2?continue=/home");
 
           deactivateGuard(guard: guard2);
           await tester.pumpAndSettle();


### PR DESCRIPTION
## 0.0.15

- fix: cover continue path resolution for sequential Guard1→Guard2 flow in nested and flattened shield